### PR TITLE
feat(libs): highlight outdated versions

### DIFF
--- a/html/data/app-deps.csv
+++ b/html/data/app-deps.csv
@@ -1,8 +1,8 @@
 library,latest version,charmcraft/main,charmcraft/hotfix/2.6,rockcraft/main,rockcraft/hotfix/1.3,snapcraft/main,snapcraft/hotfix/7.5,snapcraft/hotfix/8.0
-craft-application,2.5.0,✗ 2.4.0,not used,✗ 2.4.0,✗ 2.4.0,2.5.0,not used,not used
+craft-application,2.5.0,!2.4.0,not used,!2.4.0,!2.4.0,2.5.0,not used,not used
 craft-archives,1.1.3,1.1.3,not used,1.1.3,1.1.3,1.1.3,1.1.3,1.1.3
-craft-cli,2.5.1,2.5.1,✗ 2.4.0,2.5.1,2.5.1,2.5.1,✗ 1.2.0,2.5.1
-craft-grammar,1.2.0,1.2.0,not used,not used,not used,1.2.0,✗ 1.1.1,✗ 1.1.2
-craft-parts,1.29.0,1.29.0,✗ 1.25.2,1.29.0,1.29.0,1.29.0,✗ 1.19.7,✗ 1.26.2
-craft-providers,1.23.1,1.23.1,✗ 1.20.3,1.23.1,1.23.1,1.23.1,✗ 1.20.2,1.23.1
-craft-store,2.6.1,2.6.1,✗ 2.5.0,not used,not used,2.6.1,✗ 2.5.0,✗ 2.6.0
+craft-cli,2.5.1,2.5.1,!2.4.0,2.5.1,2.5.1,2.5.1,!1.2.0,2.5.1
+craft-grammar,1.2.0,1.2.0,not used,not used,not used,1.2.0,!1.1.1,!1.1.2
+craft-parts,1.29.0,1.29.0,!1.25.2,1.29.0,1.29.0,1.29.0,!1.19.7,!1.26.2
+craft-providers,1.23.1,1.23.1,!1.20.3,1.23.1,1.23.1,1.23.1,!1.20.2,1.23.1
+craft-store,2.6.1,2.6.1,!2.5.0,not used,not used,2.6.1,!2.5.0,!2.6.0

--- a/html/index.html
+++ b/html/index.html
@@ -6,6 +6,11 @@
   <script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.js"></script>
   <script type="module" src="index.js"></script>
+  <style>
+    .outdated { color: #d00000; }
+    .outdated:before { content: "\2717\a0"; }
+    .not-used { color: gray; }
+  </style>
 </head>
 
 <body class="is-paper">
@@ -19,7 +24,7 @@
     </div>
     <div class="row--25-75" id="libs-and-apps">
       <div class="col">
-        <p class="p-muted-heading">Libraries & Applications</p>
+        <p class="p-muted-heading">Libraries &amp; Applications</p>
       </div>
       <div class="col">
         <div id="libs-and-apps-table" class="p-section"></div>
@@ -28,7 +33,7 @@
     </div>
     <div class="row--25-75" id="releases-and-commits">
       <div class="col">
-        <p class="p-muted-heading">Releases & Commits</p>
+        <p class="p-muted-heading">Releases &amp; Commits</p>
       </div>
       <div class="col">
         <div id="releases-and-commits-table" class="p-section"></div>

--- a/html/index.js
+++ b/html/index.js
@@ -20,8 +20,17 @@ function chartData(data, id) {
     // Iterate through the row's data and create cells
     rowData.forEach(function(cellData) {
       var cell = document.createElement(row_name);
-      cell.setAttribute("class", "u-align--right")
-      var textNode = document.createTextNode(cellData);
+      let text = cellData.toString()
+      let attr = "u-align--right"
+      if (text.startsWith("!")) {
+        attr += " outdated"
+        text = text.replace("!", "")
+      } else if (text == "not used") {
+        attr += " not-used"
+      }
+      cell.setAttribute("class", attr)
+
+      var textNode = document.createTextNode(text);
       cell.appendChild(textNode);
       row.appendChild(cell);
     });

--- a/starcraft_stats/dependencies.py
+++ b/starcraft_stats/dependencies.py
@@ -109,6 +109,6 @@ def _get_reqs_for_project(
         if library_version == library_versions[library_name]:
             libraries[library_name] = f"{library_version}"
         elif library_version not in ["unknown", "not used"]:
-            libraries[library_name] = f"✗ {library_version}"
+            libraries[library_name] = f"!{library_version}"
 
     return libraries


### PR DESCRIPTION
Display outdated library version numbers in a different color to make
it easier to spot older releases being used,  and decouple the outdated
version internal encoding from the presentation format (handled by css).

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
