### PR TITLE
feat(deps): outdated versions based on branch series

### DIFF
--- a/html/data/app-deps.csv
+++ b/html/data/app-deps.csv
@@ -1,8 +1,0 @@
-library,latest version,charmcraft/main,charmcraft/hotfix/2.6,rockcraft/main,rockcraft/hotfix/1.3,snapcraft/main,snapcraft/hotfix/7.5,snapcraft/hotfix/8.0
-craft-application,2.6.0,!2.5.0,not used,!2.4.0,!2.4.0,!2.5.0,not used,not used
-craft-archives,1.1.3,1.1.3,not used,1.1.3,1.1.3,1.1.3,1.1.3,1.1.3
-craft-cli,2.5.1,2.5.1,!2.4.0,2.5.1,2.5.1,2.5.1,!1.2.0,2.5.1
-craft-grammar,1.2.0,1.2.0,not used,not used,not used,1.2.0,!1.1.1,!1.1.2
-craft-parts,1.29.0,1.29.0,!1.25.2,1.29.0,1.29.0,1.29.0,!1.19.7,!1.26.2
-craft-providers,1.23.1,1.23.1,!1.20.3,1.23.1,1.23.1,1.23.1,!1.20.2,1.23.1
-craft-store,2.6.1,2.6.1,!2.5.0,not used,not used,2.6.1,!2.5.0,!2.6.0

--- a/html/data/app-deps.json
+++ b/html/data/app-deps.json
@@ -1,0 +1,282 @@
+{
+    "libs": [
+        "craft-application",
+        "craft-archives",
+        "craft-cli",
+        "craft-grammar",
+        "craft-parts",
+        "craft-providers",
+        "craft-store"
+    ],
+    "latest": {
+        "craft-application": "2.6.0",
+        "craft-archives": "1.1.3",
+        "craft-cli": "2.5.1",
+        "craft-grammar": "1.2.0",
+        "craft-parts": "1.29.0",
+        "craft-providers": "1.23.1",
+        "craft-store": "2.6.1"
+    },
+    "apps": {
+        "charmcraft/main": {
+            "craft-application": {
+                "series": "2.5",
+                "version": "2.5.0",
+                "latest": "2.6.0",
+                "outdated": true
+            },
+            "craft-archives": {
+                "series": "1.1",
+                "version": "1.1.3",
+                "latest": "1.1.3",
+                "outdated": false
+            },
+            "craft-cli": {
+                "series": "2.5",
+                "version": "2.5.1",
+                "latest": "2.5.1",
+                "outdated": false
+            },
+            "craft-grammar": {
+                "series": "1.2",
+                "version": "1.2.0",
+                "latest": "1.2.0",
+                "outdated": false
+            },
+            "craft-parts": {
+                "series": "1.29",
+                "version": "1.29.0",
+                "latest": "1.29.0",
+                "outdated": false
+            },
+            "craft-providers": {
+                "series": "1.23",
+                "version": "1.23.1",
+                "latest": "1.23.1",
+                "outdated": false
+            },
+            "craft-store": {
+                "series": "2.6",
+                "version": "2.6.1",
+                "latest": "2.6.1",
+                "outdated": false
+            }
+        },
+        "charmcraft/hotfix/2.6": {
+            "craft-cli": {
+                "series": "2.4",
+                "version": "2.4.0",
+                "latest": "2.4.0",
+                "outdated": false
+            },
+            "craft-parts": {
+                "series": "1.25",
+                "version": "1.25.2",
+                "latest": "1.25.2",
+                "outdated": false
+            },
+            "craft-providers": {
+                "series": "1.20",
+                "version": "1.20.3",
+                "latest": "1.20.3",
+                "outdated": false
+            },
+            "craft-store": {
+                "series": "2.5",
+                "version": "2.5.0",
+                "latest": "2.5.0",
+                "outdated": false
+            }
+        },
+        "rockcraft/main": {
+            "craft-application": {
+                "series": "2.4",
+                "version": "2.4.0",
+                "latest": "2.6.0",
+                "outdated": true
+            },
+            "craft-archives": {
+                "series": "1.1",
+                "version": "1.1.3",
+                "latest": "1.1.3",
+                "outdated": false
+            },
+            "craft-cli": {
+                "series": "2.5",
+                "version": "2.5.1",
+                "latest": "2.5.1",
+                "outdated": false
+            },
+            "craft-parts": {
+                "series": "1.29",
+                "version": "1.29.0",
+                "latest": "1.29.0",
+                "outdated": false
+            },
+            "craft-providers": {
+                "series": "1.23",
+                "version": "1.23.1",
+                "latest": "1.23.1",
+                "outdated": false
+            }
+        },
+        "rockcraft/hotfix/1.3": {
+            "craft-application": {
+                "series": "2.4",
+                "version": "2.4.0",
+                "latest": "2.4.0",
+                "outdated": false
+            },
+            "craft-archives": {
+                "series": "1.1",
+                "version": "1.1.3",
+                "latest": "1.1.3",
+                "outdated": false
+            },
+            "craft-cli": {
+                "series": "2.5",
+                "version": "2.5.1",
+                "latest": "2.5.1",
+                "outdated": false
+            },
+            "craft-parts": {
+                "series": "1.29",
+                "version": "1.29.0",
+                "latest": "1.29.0",
+                "outdated": false
+            },
+            "craft-providers": {
+                "series": "1.23",
+                "version": "1.23.1",
+                "latest": "1.23.1",
+                "outdated": false
+            }
+        },
+        "snapcraft/main": {
+            "craft-application": {
+                "series": "2.6",
+                "version": "2.6.0",
+                "latest": "2.6.0",
+                "outdated": false
+            },
+            "craft-archives": {
+                "series": "1.1",
+                "version": "1.1.3",
+                "latest": "1.1.3",
+                "outdated": false
+            },
+            "craft-cli": {
+                "series": "2.5",
+                "version": "2.5.1",
+                "latest": "2.5.1",
+                "outdated": false
+            },
+            "craft-grammar": {
+                "series": "1.2",
+                "version": "1.2.0",
+                "latest": "1.2.0",
+                "outdated": false
+            },
+            "craft-parts": {
+                "series": "1.29",
+                "version": "1.29.0",
+                "latest": "1.29.0",
+                "outdated": false
+            },
+            "craft-providers": {
+                "series": "1.23",
+                "version": "1.23.1",
+                "latest": "1.23.1",
+                "outdated": false
+            },
+            "craft-store": {
+                "series": "2.6",
+                "version": "2.6.1",
+                "latest": "2.6.1",
+                "outdated": false
+            }
+        },
+        "snapcraft/hotfix/8.2": {
+            "craft-application": {
+                "series": "2.6",
+                "version": "2.6.0",
+                "latest": "2.6.0",
+                "outdated": false
+            },
+            "craft-archives": {
+                "series": "1.1",
+                "version": "1.1.3",
+                "latest": "1.1.3",
+                "outdated": false
+            },
+            "craft-cli": {
+                "series": "2.5",
+                "version": "2.5.1",
+                "latest": "2.5.1",
+                "outdated": false
+            },
+            "craft-grammar": {
+                "series": "1.2",
+                "version": "1.2.0",
+                "latest": "1.2.0",
+                "outdated": false
+            },
+            "craft-parts": {
+                "series": "1.29",
+                "version": "1.29.0",
+                "latest": "1.29.0",
+                "outdated": false
+            },
+            "craft-providers": {
+                "series": "1.23",
+                "version": "1.23.1",
+                "latest": "1.23.1",
+                "outdated": false
+            },
+            "craft-store": {
+                "series": "2.6",
+                "version": "2.6.1",
+                "latest": "2.6.1",
+                "outdated": false
+            }
+        },
+        "snapcraft/hotfix/7.5": {
+            "craft-archives": {
+                "series": "1.1",
+                "version": "1.1.3",
+                "latest": "1.1.3",
+                "outdated": false
+            },
+            "craft-cli": {
+                "series": "1.2",
+                "version": "1.2.0",
+                "latest": "1.2.0",
+                "outdated": false
+            },
+            "craft-grammar": {
+                "series": "1.1",
+                "version": "1.1.1",
+                "latest": "1.1.2",
+                "outdated": true
+            },
+            "craft-parts": {
+                "series": "1.19",
+                "version": "1.19.7",
+                "latest": "1.19.7",
+                "outdated": false
+            },
+            "craft-providers": {
+                "series": "1.20",
+                "version": "1.20.2",
+                "latest": "1.20.3",
+                "outdated": true
+            },
+            "craft-store": {
+                "series": "2.5",
+                "version": "2.5.0",
+                "latest": "2.5.0",
+                "outdated": false
+            }
+        }
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "craft-providers",
     "craft-store",
     "dparse",
+    "dataclasses-json",
     "gitpython",
     "launchpadlib",
     # pydantic is implicitly pinned to 1.x via the craft libraries :(

--- a/starcraft-config.yaml
+++ b/starcraft-config.yaml
@@ -10,8 +10,8 @@ craft-applications:
   - name: snapcraft
     branches:
       - main
+      - hotfix/8.2
       - hotfix/7.5
-      - hotfix/8.0
 
 craft-libraries:
   - craft-application

--- a/starcraft_stats/config.py
+++ b/starcraft_stats/config.py
@@ -61,6 +61,8 @@ class Config(CraftBaseModel):
                     f"https://github.com/{app.owner}/{app.name}",
                     branch_regex,
                 )
+                if not raw_head_data:
+                    continue
                 # convert head data into a list of branch names
                 branches: list[str] = [  # type: ignore[reportUnknownVariableType]
                     item.split("\t")[1][11:] for item in raw_head_data.split("\n")  # type: ignore[reportUnknownVariableType]

--- a/starcraft_stats/dependencies.py
+++ b/starcraft_stats/dependencies.py
@@ -1,17 +1,42 @@
 """Fetch craft library requirements for an application."""
 
 import argparse
-import csv
+import json
 import pathlib
 import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
 
 import requests
 from craft_cli import BaseCommand, emit
+from dataclasses_json import dataclass_json
 from dparse import filetypes, parse  # type: ignore[import-untyped]
+from packaging.version import Version
 
 from .config import CONFIG_FILE, Config, CraftApplicationBranch
 
-DATA_FILE = pathlib.Path("html/data/app-deps.csv")
+DATA_FILE = pathlib.Path("html/data/app-deps.json")
+
+
+@dataclass_json
+@dataclass
+class Dependency:
+    """Craft application dependency."""
+
+    series: str
+    version: str
+    latest: str
+    outdated: bool
+
+
+@dataclass_json
+@dataclass
+class DependencyTable:
+    """The table containing application dependencies."""
+
+    libs: list[str]
+    latest: dict[str, str]
+    apps: dict[str, dict[str, Dependency]]
 
 
 class GetDependenciesCommand(BaseCommand):
@@ -28,64 +53,53 @@ class GetDependenciesCommand(BaseCommand):
     ) -> None:
         """Fetch craft library requirements for all applications.
 
-        Data is stored in a CSV formatted as:
-
-        | library   | library's latest version | application 1 | ... |
-        | --------- | -------------------------| ------------- | ... |
-        | library 1 | 1.2.3                    | 1.2.3         | ... |
-        | ...       | ...                      | ...           | ... |
-
         :param parsed_args: parsed command line arguments
         """
         config = Config.from_yaml_file(CONFIG_FILE)
 
-        library_versions: dict[str, str] = {}
+        library_versions: dict[str, dict[str, str]] = {}
+        latest: dict[str, str] = {}
+
         # libraries are already installed via project dependencies
         for library in config.craft_libraries:
             emit.debug(f"Collecting version for {library}")
-            output = subprocess.check_output(
-                ["pip", "show", library, "--disable-pip-version-check"],
+            versions = _get_pip_versions(library)
+            latest[library], library_versions[library] = _latest_series_version(
+                versions,
             )
-            # get version from output
-            version = output.decode("utf-8").split("\n")[1].split(": ")[1]
-            emit.message(f"Parsed version {version} for {library}")
-            library_versions[library] = version
+            emit.message(f"Parsed latest versions for {library}")
 
         # a mapping of application branches to their requirements
-        app_reqs: dict[CraftApplicationBranch, dict[str, str]] = {}
+        app_reqs: dict[str, dict[str, Dependency]] = {}
 
         # fetch requirements for each application
         for app in config.application_branches:
-            app_reqs[app] = _get_reqs_for_project(
+            app_reqs[f"{app}"] = _get_reqs_for_project(
                 app,
+                latest,
                 library_versions,
                 config.craft_libraries,
             )
+            emit.message(f"Parsed requirements for {app}")
 
-        # write data to a csv in a ready-to-display format
+        table = DependencyTable(
+            libs=config.craft_libraries,
+            latest=latest,
+            apps=app_reqs,
+        )
+
+        # write dependency data to a json file
         emit.debug(f"Writing data to {DATA_FILE}")
-        with DATA_FILE.open("w", encoding="utf-8") as file:
-            writer = csv.writer(file, lineterminator="\n")
-            writer.writerow(["library", "latest version", *config.application_branches])
-            for library in config.craft_libraries:
-                writer.writerow(
-                    [
-                        library,
-                        library_versions[library],
-                        *[
-                            app_reqs[app][library]
-                            for app in config.application_branches
-                        ],
-                    ],
-                )
+        pathlib.Path(DATA_FILE).write_text(json.dumps(table.to_dict(), indent=4))  # type: ignore[attr-defined]
         emit.message(f"Wrote to {DATA_FILE}")
 
 
 def _get_reqs_for_project(
     app: CraftApplicationBranch,
-    library_versions: dict[str, str],
+    latest: dict[str, str],
+    library_versions: dict[str, dict[str, str]],
     craft_libraries: list[str],
-) -> dict[str, str]:
+) -> dict[str, Dependency]:
     """Fetch craft library requirements for an application.
 
     :returns: A list of library names and their version.
@@ -112,14 +126,72 @@ def _get_reqs_for_project(
     # filter for craft library deps
     libraries = {lib: deps.get(lib, "not used") for lib in craft_libraries}
 
+    dlist: dict[str, Dependency] = {}
     emit.debug(f"Collected requirements for {app.name}:")
     for library_name, library_version in libraries.items():
         emit.debug(f"  {library_name}: {library_version}")
 
-        # prefix a ✓ or ✗ to the version
-        if library_version == library_versions[library_name]:
-            libraries[library_name] = f"{library_version}"
-        elif library_version not in ["unknown", "not used"]:
-            libraries[library_name] = f"!{library_version}"
+        if library_version in ("unknown", "not used"):
+            continue
 
-    return libraries
+        ver = Version(library_version)
+        series = f"{ver.major}.{ver.minor}"
+
+        if app.branch == "main":
+            latest_ver = latest[library_name]
+            outdated = library_version not in (latest_ver, "unknown", "not used")
+        else:
+            # get latest version from series
+            latest_ver = library_versions[library_name].get(series, "")
+            if latest_ver:
+                outdated = library_version not in (latest_ver, "unknown", "not used")
+            else:
+                outdated = False
+
+        dlist[library_name] = Dependency(
+            series=series,
+            version=library_version,
+            latest=latest_ver,
+            outdated=outdated,
+        )
+
+    return dlist
+
+
+def _latest_series_version(versions: list[str]) -> tuple[str, dict[str, str]]:
+    series_versions: dict[str, list[str]] = defaultdict(list)
+    for version in versions:
+        ver = Version(version)
+        series = f"{ver.major}.{ver.minor}"
+        series_versions[series].append(version)
+
+    latest_ver = "0.0.0"
+    series_map: dict[str, str] = {}
+    for k, v in series_versions.items():
+        v.sort(key=Version, reverse=True)
+        series_map[k] = v[0]
+        if Version(v[0]) > Version(latest_ver):
+            latest_ver = v[0]
+
+    return latest_ver, series_map
+
+
+def _get_pip_versions(library: str) -> list[str]:
+    proc = subprocess.run(
+        ["pip", "install", f"{library}==", "--disable-pip-version-check"],
+        check=False,
+        capture_output=True,
+    )
+    output = proc.stderr.decode("utf-8").split("\n")[0]
+
+    # get the latest version in each major.minor seriess
+    anchor = "from versions: "
+    idx = output.find(anchor)
+    if idx < 0:
+        return []
+
+    versions = output[idx + len(anchor) : -1]
+    if versions == "none":
+        return []
+
+    return versions.split(", ")


### PR DESCRIPTION
Use the minor version of a library used in an application branch
to verify whether the library version is outdated. App dependency
data is now stored as a JSON file containing structured information
about the library series used in each branch. Outdated versions in
each branch are highlighted along with the latest version in that
series, making a dedicated latest version column unnecessary.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>

- [x] Have you successfully run `tox`?

-----
